### PR TITLE
Upgrade esbuild to v0.8.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,7 @@
 
 name: Node.js CI
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: push
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "rollup-plugin-svelte": "^6.0.0",
         "sapper": "^0.28.10",
         "svelte": "^3.29.7",
-        "svelte-check": "^1.0.41",
+        "svelte-check": "^1.1.15",
         "svelte-preprocess": "^4.2.1",
         "typescript": "^4.1.2"
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "sirv": "^1.0.6"
     },
     "devDependencies": {
-        "@rollup/plugin-commonjs": "^13.0.0",
+        "@cush/rollup-plugin-esbuild": "2.5.2-canary.138",
+        "@rollup/plugin-commonjs": "^16.0.0",
         "@rollup/plugin-node-resolve": "^8.0.1",
         "@rollup/plugin-replace": "^2.3.3",
         "@tsconfig/svelte": "^1.0.10",
@@ -30,7 +31,6 @@
         "esbuild": "^0.8.12",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.33.3",
-        "rollup-plugin-esbuild": "^2.5.2",
         "rollup-plugin-svelte": "^6.0.0",
         "sapper": "^0.28.10",
         "svelte": "^3.29.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@types/compression": "^1.7.0",
         "@types/polka": "^0.5.1",
         "chokidar-cli": "^2.1.0",
-        "esbuild": "0.6.33",
+        "esbuild": "^0.8.12",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.33.3",
         "rollup-plugin-esbuild": "^2.5.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import resolve from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
 import commonjs from '@rollup/plugin-commonjs'
 import svelte from 'rollup-plugin-svelte'
-import esbuild from 'rollup-plugin-esbuild'
+import esbuild from '@cush/rollup-plugin-esbuild'
 import config from 'sapper/config/rollup'
 import sveltePreprocess from 'svelte-preprocess'
 import pkg from './package.json'
@@ -17,10 +17,7 @@ const sapperVersion = pkg.devDependencies.sapper.match(/[0-9]{1,5}/g).map(el => 
 const optimizer = server => esbuild({
     include: /\.[jt]sx?$/,
     minify: server ? (sapperVersion[1] >= 28 && sapperVersion[2] > 0) ? false : true : true,
-    target: 'es2017',
-    loaders: {
-        '.json': 'json'
-    }
+    target: 'es2017'
 })
 
 const warningIsIgnored = (warning) => warning.message.includes(
@@ -55,10 +52,8 @@ export default {
 	},
 
 	server: {
-        input: {
-            server: config.server.input().server.replace(/\.js$/, '.ts')
-        },
-		output: { ...config.server.output(), sourcemap },
+        input: config.server.input().server.replace(/\.js$/, '.ts'),
+		output: config.server.output(),
 		plugins: [
 			replace({
 				"process.browser": false,


### PR DESCRIPTION
As of `rollup-plugin-esbuild@2.5.2`, it was not possible to upgrade `esbuild` without running into breaking change related issues. This PR will ditch `rollup-plugin-esbuild` for `@cush/rollup-plugin-esbuild` which implemented the PR fix.

Closes #7 